### PR TITLE
Implement multi-environment settings for Demo/Live accounts

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -13,6 +13,9 @@ class MainApplication(tk.Tk):
         self.geometry("600x400")
 
         self.settings = Settings.load()
+        # The Trader instance is initialized with the settings loaded at startup.
+        # If active_environment is changed in settings, the application
+        # currently needs to be restarted for the Trader to use the new environment.
         self.trader = Trader(self.settings)
 
         container = ttk.Frame(self)
@@ -187,18 +190,111 @@ class SettingsPage(ttk.Frame):
     def __init__(self, parent, controller):
         super().__init__(parent)
         self.controller = controller
-        ttk.Label(self, text="Settings Page").pack(pady=10)
-        ttk.Label(self, text="API Key").pack()
-        self.api_key_entry = ttk.Entry(self)
-        self.api_key_entry.insert(0, controller.settings.api_key)
-        self.api_key_entry.pack()
-        ttk.Button(self, text="Save", command=self.save).pack(pady=10)
-        ttk.Button(self, text="Back", command=lambda: controller.show_frame("TradingPage")).pack()
+        self.configure(padding="10 10 10 10")
 
-    def save(self):
-        self.controller.settings.api_key = self.api_key_entry.get()
-        self.controller.settings.save()
+        ttk.Label(self, text="Application Settings", font=("Arial", 16, "bold")).pack(pady=(0,15))
 
+        # --- Environment Selection ---
+        env_frame = ttk.Frame(self)
+        env_frame.pack(fill="x", pady=5)
+
+        ttk.Label(env_frame, text="Active Environment:").pack(side="left", padx=(0,10))
+        self.environment_var = tk.StringVar(value=self.controller.settings.active_environment.capitalize())
+        self.environment_cb = ttk.Combobox(
+            env_frame,
+            textvariable=self.environment_var,
+            values=["Demo", "Live"],
+            state="readonly"
+        )
+        self.environment_cb.pack(side="left")
+        self.environment_cb.bind("<<ComboboxSelected>>", self.on_environment_change)
+
+        # --- Credentials Frame ---
+        # Using Labelframe for better visual grouping of credentials
+        credentials_frame = ttk.Labelframe(self, text="Environment Credentials", padding="10")
+        credentials_frame.pack(fill="x", expand=True, pady=10)
+
+        # API Key
+        ttk.Label(credentials_frame, text="API Key:").grid(row=0, column=0, padx=5, pady=5, sticky="w")
+        self.api_key_var = tk.StringVar()
+        self.api_key_entry = ttk.Entry(credentials_frame, textvariable=self.api_key_var, width=50)
+        self.api_key_entry.grid(row=0, column=1, padx=5, pady=5, sticky="ew")
+
+        # Account ID
+        ttk.Label(credentials_frame, text="Account ID:").grid(row=1, column=0, padx=5, pady=5, sticky="w")
+        self.account_id_var = tk.StringVar()
+        self.account_id_entry = ttk.Entry(credentials_frame, textvariable=self.account_id_var, width=50)
+        self.account_id_entry.grid(row=1, column=1, padx=5, pady=5, sticky="ew")
+
+        # Broker URL
+        ttk.Label(credentials_frame, text="Broker URL:").grid(row=2, column=0, padx=5, pady=5, sticky="w")
+        self.broker_url_var = tk.StringVar()
+        self.broker_url_entry = ttk.Entry(credentials_frame, textvariable=self.broker_url_var, width=50)
+        self.broker_url_entry.grid(row=2, column=1, padx=5, pady=5, sticky="ew")
+
+        credentials_frame.columnconfigure(1, weight=1) # Make entry fields expand
+
+        # --- Action Buttons ---
+        action_frame = ttk.Frame(self)
+        action_frame.pack(fill="x", pady=10)
+
+        self.save_button = ttk.Button(action_frame, text="Save Settings", command=self.save_settings, style="Accent.TButton")
+        self.save_button.pack(side="left", padx=5)
+
+        self.back_button = ttk.Button(action_frame, text="Back to Trading", command=lambda: controller.show_frame("TradingPage"))
+        self.back_button.pack(side="right", padx=5)
+
+        # Load initial values when frame is created
+        self.load_current_environment_settings()
+
+    def load_current_environment_settings(self):
+        """Loads credentials into UI fields based on selected environment."""
+        env = self.environment_var.get().lower() # 'demo' or 'live'
+        settings = self.controller.settings
+
+        if env == 'demo':
+            self.api_key_var.set(settings.demo_api_key)
+            self.account_id_var.set(settings.demo_account_id)
+            self.broker_url_var.set(settings.demo_broker_url)
+        elif env == 'live':
+            self.api_key_var.set(settings.live_api_key)
+            self.account_id_var.set(settings.live_account_id)
+            self.broker_url_var.set(settings.live_broker_url)
+
+    def on_environment_change(self, event=None):
+        """Handles environment selection change."""
+        # First, save any pending changes to the *previously* selected environment
+        # This is a bit complex if we want to save before switching.
+        # For simplicity now, we can prompt user or just load.
+        # Let's just load for now. A more robust solution might ask to save current changes.
+        self.load_current_environment_settings()
+        # The active_environment in actual settings will be updated on Save.
+
+    def save_settings(self):
+        """Saves the currently displayed credentials to the selected environment in settings."""
+        env = self.environment_var.get().lower()
+        settings = self.controller.settings
+
+        settings.active_environment = env # Update active environment
+
+        api_key = self.api_key_var.get()
+        account_id = self.account_id_var.get()
+        broker_url = self.broker_url_var.get()
+
+        if env == 'demo':
+            settings.demo_api_key = api_key
+            settings.demo_account_id = account_id
+            settings.demo_broker_url = broker_url
+        elif env == 'live':
+            settings.live_api_key = api_key
+            settings.live_account_id = account_id
+            settings.live_broker_url = broker_url
+
+        settings.save()
+        # Optionally, provide feedback to the user
+        # For example, using the TradingPage's feedback label if we passed a reference
+        # or adding a temporary status label to SettingsPage itself.
+        print("Settings saved.") # Placeholder feedback
 
 class ActivityPage(ttk.Frame):
     def __init__(self, parent, controller):

--- a/settings.py
+++ b/settings.py
@@ -8,9 +8,39 @@ CONFIG_FILE = os.path.join(os.path.dirname(__file__), 'config.json')
 
 @dataclass
 class Settings:
+    # New environment-specific fields
+    demo_api_key: str = ''
+    demo_account_id: str = ''
+    demo_broker_url: str = 'https://ct-api.icmarkets.com/trading/demo' # Example URL
+    live_api_key: str = ''
+    live_account_id: str = ''
+    live_broker_url: str = 'https://ct-api.icmarkets.com/trading/live' # Example URL
+
+    active_environment: str = 'demo'  # 'demo' or 'live'
+
+    # Deprecated generic fields (kept for potential migration)
     api_key: str = ''
     account_id: str = ''
-    broker_url: str = 'https://api.icmarkets.com'
+    broker_url: str = ''
+
+    def __post_init__(self):
+        # Simple migration: if new fields are empty and old ones have values, migrate.
+        # This is a basic approach. A more robust migration might involve versioning.
+        if not self.demo_api_key and self.api_key and self.active_environment == 'demo':
+            self.demo_api_key = self.api_key
+            self.demo_account_id = self.account_id
+            self.demo_broker_url = self.broker_url if self.broker_url else 'https://ct-api.icmarkets.com/trading/demo'
+            self.api_key = '' # Clear old fields after migration
+            self.account_id = ''
+            self.broker_url = ''
+        elif not self.live_api_key and self.api_key and self.active_environment == 'live':
+            # This case is less likely for old configs unless active_environment was somehow set to live
+            self.live_api_key = self.api_key
+            self.live_account_id = self.account_id
+            self.live_broker_url = self.broker_url if self.broker_url else 'https://ct-api.icmarkets.com/trading/live'
+            self.api_key = '' # Clear old fields
+            self.account_id = ''
+            self.broker_url = ''
 
     @classmethod
     def load(cls) -> 'Settings':
@@ -18,7 +48,22 @@ class Settings:
             try:
                 with open(CONFIG_FILE, 'r') as f:
                     data = json.load(f)
-                return cls(**data)
+
+                # Handle potential absence of new fields in older config files
+                settings_data = {
+                    'demo_api_key': data.get('demo_api_key', data.get('api_key', '') if data.get('active_environment', 'demo') == 'demo' else ''),
+                    'demo_account_id': data.get('demo_account_id', data.get('account_id', '') if data.get('active_environment', 'demo') == 'demo' else ''),
+                    'demo_broker_url': data.get('demo_broker_url', data.get('broker_url', 'https://ct-api.icmarkets.com/trading/demo') if data.get('active_environment', 'demo') == 'demo' else 'https://ct-api.icmarkets.com/trading/demo'),
+                    'live_api_key': data.get('live_api_key', data.get('api_key', '') if data.get('active_environment') == 'live' else ''),
+                    'live_account_id': data.get('live_account_id', data.get('account_id', '') if data.get('active_environment') == 'live' else ''),
+                    'live_broker_url': data.get('live_broker_url', data.get('broker_url', 'https://ct-api.icmarkets.com/trading/live') if data.get('active_environment') == 'live' else 'https://ct-api.icmarkets.com/trading/live'),
+                    'active_environment': data.get('active_environment', 'demo'),
+                    # Load deprecated fields too, __post_init__ might use them for migration if new ones are missing
+                    'api_key': data.get('api_key', ''),
+                    'account_id': data.get('account_id', ''),
+                    'broker_url': data.get('broker_url', '')
+                }
+                return cls(**settings_data)
             except json.JSONDecodeError:
                 print(f"Warning: Could not decode JSON from {CONFIG_FILE}. Using default settings.")
             except Exception as e:
@@ -26,5 +71,14 @@ class Settings:
         return cls()
 
     def save(self) -> None:
+        # Ensure deprecated fields are not saved if they were cleared by migration
+        data_to_save = self.__dict__.copy()
+        # We don't need to explicitly remove api_key, account_id, broker_url if they are empty
+        # as they are part of the dataclass. Saving them as empty is fine.
+        # However, if we wanted to strictly not save them:
+        # for key in ['api_key', 'account_id', 'broker_url']:
+        #     if not data_to_save.get(key): # if empty or None
+        #         data_to_save.pop(key, None)
+
         with open(CONFIG_FILE, 'w') as f:
-            json.dump(self.__dict__, f, indent=2)
+            json.dump(data_to_save, f, indent=2)

--- a/trading.py
+++ b/trading.py
@@ -3,8 +3,31 @@ from typing import List, Optional
 
 # Placeholder for actual cTrader API integration
 class Trader:
-    def __init__(self, settings):
-        self.settings = settings
+    def __init__(self, settings_obj: 'Settings'): # Type hint with quotes for forward reference
+        self.settings = settings_obj # Keep original settings if needed for other things
+
+        if self.settings.active_environment == 'demo':
+            self.active_api_key = self.settings.demo_api_key
+            self.active_account_id = self.settings.demo_account_id
+            self.active_broker_url = self.settings.demo_broker_url
+            self.mode = "DEMO"
+        elif self.settings.active_environment == 'live':
+            self.active_api_key = self.settings.live_api_key
+            self.active_account_id = self.settings.live_account_id
+            self.active_broker_url = self.settings.live_broker_url
+            self.mode = "LIVE"
+        else:
+            # Default to demo or raise an error if active_environment is invalid
+            print(f"Warning: Invalid active_environment '{self.settings.active_environment}'. Defaulting to DEMO mode configuration.")
+            self.active_api_key = self.settings.demo_api_key
+            self.active_account_id = self.settings.demo_account_id
+            self.active_broker_url = self.settings.demo_broker_url
+            self.mode = "DEMO (fallback)"
+
+        # For actual API integration, you would initialize your API client here
+        # using self.active_api_key, self.active_account_id, self.active_broker_url
+        print(f"Trader initialized in {self.mode} mode. URL: {self.active_broker_url}, Account: {self.active_account_id}")
+
 
     def open_trade(self, symbol: str, volume: float, direction: str, stop_loss: Optional[float] = None, take_profit: Optional[float] = None):
         """Open a trade. Direction should be 'buy' or 'sell'."""
@@ -23,23 +46,25 @@ class Trader:
         # Further validation for SL/TP values (e.g., SL for buy must be < current price)
         # would go here once price data is available.
 
-        trade_details = f"Opening {direction} trade on {symbol} with volume {volume}"
+        trade_details = f"[{self.mode}] Opening {direction} trade on {symbol} with volume {volume}"
         if stop_loss is not None:
             trade_details += f", SL: {stop_loss}"
         if take_profit is not None:
             trade_details += f", TP: {take_profit}"
 
         print(trade_details)
-        # TODO: integrate with cTrader API using all parameters including SL/TP
+        # TODO: integrate with cTrader API using self.active_api_key, self.active_broker_url, etc.
 
     def close_trade(self, trade_id: str):
-        print(f"Closing trade {trade_id}")
+        print(f"[{self.mode}] Closing trade {trade_id}")
         # TODO: integrate with cTrader API
 
     def get_open_trades(self) -> List[dict]:
-        print("Fetching open trades")
+        print(f"[{self.mode}] Fetching open trades")
+        # TODO: integrate with cTrader API
         return []
 
     def get_account_info(self) -> dict:
-        print("Fetching account info")
+        print(f"[{self.mode}] Fetching account info")
+        # TODO: integrate with cTrader API
         return {}


### PR DESCRIPTION
- Updated Settings dataclass to store demo and live credentials (API key, Account ID, Broker URL) and an active_environment flag.
- Enhanced SettingsPage GUI to allow selection of active environment (Demo/Live) and dynamically display/save corresponding credentials.
- Added basic migration for older config files in settings.py.
- Trader class now initializes using credentials for the active_environment specified in settings.
- Console output from Trader methods now indicates DEMO or LIVE mode.

## Summary by Sourcery

Implement multi-environment support by storing separate credentials for demo and live accounts, updating the settings GUI to switch and edit them, migrating legacy configs, and initializing the Trader with the active environment and annotating its console output.

New Features:
- Store separate API key, account ID, and broker URL for demo and live in Settings
- Allow switching active environment in the Settings GUI and editing environment-specific credentials
- Initialize Trader with credentials for the selected environment and prefix console logs with DEMO or LIVE mode

Enhancements:
- Add basic migration logic for older single-environment configs to populate new environment-specific fields
- Extend settings save/load to handle deprecated fields and persist new environment-specific data